### PR TITLE
Dockerize and publish to Quay

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
 !geop/target/scala-2.10/*.jar
+!scripts/docker-entrypoint.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!geop/target/scala-2.10/*.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 
-language: scala
+language: bash
 
 services:
   - docker
@@ -12,19 +12,34 @@ cache:
 
 script:
   - mkdir -p ${HOME}/.sbt
-  - docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-program-analysis-geoprocessing -w /usace-program-analysis-geoprocessing quay.io/azavea/spark:latest ./sbt "project geop" compile
+  - docker-compose -f docker-compose.ci.yml run compile
 
 before_deploy:
-  - docker run -v ${HOME}/.ivy2:/root/.ivy2 -v ${HOME}/.sbt:/root/.sbt -v ${PWD}:/usace-program-analysis-geoprocessing -w /usace-program-analysis-geoprocessing quay.io/azavea/spark:latest ./sbt "project geop" assembly
-  - sudo chown ${USER} geop/target/scala-2.10/usace-programanalysis-geop-assembly-${TRAVIS_TAG}.jar
+  - docker login -e . -p "${QUAY_PASSWORD}" -u "${QUAY_USER}" quay.io
+  - docker-compose -f docker-compose.ci.yml run assembly
+  - sudo chown ${USER} geop/target/scala-2.10/usace-programanalysis-geop-assembly-*.jar
 
 deploy:
-  provider: releases
-  api_key:
-    secure: Kueq5wDVSor5lP9QuCouCu4tDd6TL7O1J3d9mISrYlM6PK3C1Z72cr9kxtySW+BOYYAI//J9SK3taXKNhHce7rZNdtJADyKaz8bMZ88NIKLPqujJxIXlyAmPURSXBLn2HZ9h8FjIqIw5240jFrPInDPJq2S8KiJsyEPSmI//zFUc7v32aId1XWAeRFRBGQyYiIngsrFAZ1csmwS7UlBxdl3moTZNvekgnYnYZ1GnJxaZClMa/Ii9seqHQCPtu/a7eye5WigI62rJ5a6WcLqL2/Ffx17o089TArYdLHXyfMMAsjImnNF7Lk+kMo3ybZI5u6/icL3zOY8mkn6zQxeCXTc7fwkTzSxLeIoDuoWASHJhkNrFQKg+ZsowpYefGsYv076bYkg+YtckWsIjWyNknuTkkDF5dKxLHZvffn6RmYjikbUbHo6J52q1nTFCvi6rhPU2ossIDiWjLUGRKUF6X9n9DKaFdthFj99ECsfF56zWvgcS1SSDdPmWh1r8v4oNr8I7ow9HqpOtye1XglRc4zNHHs8mjUueGCJOqOc2NZ15aMGrL8KIqTQzEDtw/ve6Fai3pmk4t8z6r2PyVZJL2RlPXfpmHlQL3JErW+hbtGNmLpP2QTVF2kz2OJkXNRZwIAY+wMX5Enw4tI447rBnfW+SPYJff/YxntoBLLJCKqo=
-  file:
-    - geop/target/scala-2.10/usace-programanalysis-geop-assembly-${TRAVIS_TAG}.jar
-  skip_cleanup: true
-  on:
-    repo: azavea/usace-program-analysis-geoprocessing
-    tags: true
+  - provider: releases
+    api_key:
+      secure: Kueq5wDVSor5lP9QuCouCu4tDd6TL7O1J3d9mISrYlM6PK3C1Z72cr9kxtySW+BOYYAI//J9SK3taXKNhHce7rZNdtJADyKaz8bMZ88NIKLPqujJxIXlyAmPURSXBLn2HZ9h8FjIqIw5240jFrPInDPJq2S8KiJsyEPSmI//zFUc7v32aId1XWAeRFRBGQyYiIngsrFAZ1csmwS7UlBxdl3moTZNvekgnYnYZ1GnJxaZClMa/Ii9seqHQCPtu/a7eye5WigI62rJ5a6WcLqL2/Ffx17o089TArYdLHXyfMMAsjImnNF7Lk+kMo3ybZI5u6/icL3zOY8mkn6zQxeCXTc7fwkTzSxLeIoDuoWASHJhkNrFQKg+ZsowpYefGsYv076bYkg+YtckWsIjWyNknuTkkDF5dKxLHZvffn6RmYjikbUbHo6J52q1nTFCvi6rhPU2ossIDiWjLUGRKUF6X9n9DKaFdthFj99ECsfF56zWvgcS1SSDdPmWh1r8v4oNr8I7ow9HqpOtye1XglRc4zNHHs8mjUueGCJOqOc2NZ15aMGrL8KIqTQzEDtw/ve6Fai3pmk4t8z6r2PyVZJL2RlPXfpmHlQL3JErW+hbtGNmLpP2QTVF2kz2OJkXNRZwIAY+wMX5Enw4tI447rBnfW+SPYJff/YxntoBLLJCKqo=
+    file:
+      - geop/target/scala-2.10/usace-programanalysis-geop-assembly-${TRAVIS_TAG}.jar
+    skip_cleanup: true
+    on:
+      repo: azavea/usace-program-analysis-geoprocessing
+      tags: true
+
+  - provider: script
+    script: "scripts/cibuild.sh"
+    skip_cleanup: true
+    on:
+      repo: azavea/usace-program-analysis-geoprocessing
+      branch: develop
+
+  - provider: script
+    script: "scripts/cibuild.sh"
+    skip_cleanup: true
+    on:
+      repo: azavea/usace-program-analysis-geoprocessing
+      tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/azavea/spark:1.6.1
+
+ENV VERSION 0.1.0
+
+COPY geop/target/scala-2.10/usace-programanalysis-geop-assembly-${VERSION}.jar /opt/geoprocessing/
+
+WORKDIR /opt/geoprocessing
+
+EXPOSE 8090
+
+ENTRYPOINT ["/bin/bash", "-c", "spark-submit /opt/geoprocessing/usace-programanalysis-geop-assembly-${VERSION}.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ WORKDIR /opt/geoprocessing
 
 EXPOSE 8090
 
+VOLUME /tmp
+
 ENTRYPOINT ["/bin/bash", "-c", "spark-submit /opt/geoprocessing/usace-programanalysis-geop-assembly-${VERSION}.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM quay.io/azavea/spark:1.6.1
 
 ENV VERSION 0.1.0
 
-COPY geop/target/scala-2.10/usace-programanalysis-geop-assembly-${VERSION}.jar /opt/geoprocessing/
+COPY geop/target/scala-2.10/usace-programanalysis-geop-assembly-${VERSION}.jar /opt/geoprocessing/usace-programanalysis-geop.jar
+COPY scripts/docker-entrypoint.sh /opt/geoprocessing/
 
 WORKDIR /opt/geoprocessing
 
@@ -10,4 +11,4 @@ EXPOSE 8090
 
 VOLUME /tmp
 
-ENTRYPOINT ["/bin/bash", "-c", "spark-submit /opt/geoprocessing/usace-programanalysis-geop-assembly-${VERSION}.jar"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ To test with the [main web app](https://github.com/azavea/usace-program-analysis
 
 ## Deploy
 
-Deployments to GitHub Releases are handled via [Travis-CI](https://travis-ci.org/azavea/usace-program-analysis-geoprocessing). The following `git-flow` commands signal to Travis that we want to create a release. The `version` variable should be updated in `project/Version.scala.`
+Deployments to [GitHub Releases](https://github.com/azavea/usace-program-analysis-geoprocessing/releases) and [Quay](https://quay.io/repository/usace/program-analysis-geoprocessing) are handled via [Travis-CI](https://travis-ci.org/azavea/usace-program-analysis-geoprocessing). The following `git-flow` commands signal to Travis that we want to create a release. The `version` variable should be updated in `project/Version.scala` and `Dockerfile`.
 
 ``` bash
 $ git flow release start 0.0.1
 $ vim CHANGELOG.md
 $ vim project/Version.scala
+$ vim Dockerfile
 $ git commit -m "0.0.1"
 $ git flow release publish 0.0.1
 $ git flow release finish 0.0.1

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,19 @@
+assembly:
+  image: quay.io/azavea/spark:1.6.1
+  volumes:
+    - ./:/usace-program-analysis-geoprocessing
+    - ${HOME}/.ivy2:/root/.ivy2
+    - ${HOME}/.sbt:/root/.sbt
+  working_dir: /usace-program-analysis-geoprocessing
+  entrypoint: sbt
+  command: '"project geop" assembly'
+
+compile:
+  image: quay.io/azavea/spark:1.6.1
+  volumes:
+    - ./:/usace-program-analysis-geoprocessing
+    - ${HOME}/.ivy2:/root/.ivy2
+    - ${HOME}/.sbt:/root/.sbt
+  working_dir: /usace-program-analysis-geoprocessing
+  entrypoint: sbt
+  command: '"project geop" compile'

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,10 +4,10 @@ object Version {
   def either(environmentVariable: String, default: String): String =
     Properties.envOrElse(environmentVariable, default)
 
-  val version = "0.0.1"
+  val version = "0.1.0"
 
   val geotrellis  = "0.10.0"
   val scala       = either("SCALA_VERSION", "2.10.6")
   lazy val hadoop = either("SPARK_HADOOP_VERSION", "2.6.0")
-  lazy val spark  = either("SPARK_VERSION", "1.5.2")
+  lazy val spark  = either("SPARK_VERSION", "1.6.1")
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+if [ -z "${TRAVIS_TAG}" ]; then
+    QUAY_TAG="${TRAVIS_COMMIT:0:7}"
+else
+    QUAY_TAG="${TRAVIS_TAG}"
+fi
+
+docker build -t "quay.io/usace/program-analysis-geoprocessing:${QUAY_TAG}" .
+
+docker push "quay.io/usace/program-analysis-geoprocessing:${QUAY_TAG}"
+docker tag -f "quay.io/usace/program-analysis-geoprocessing:${QUAY_TAG}" "quay.io/usace/program-analysis-geoprocessing:latest"
+docker push "quay.io/usace/program-analysis-geoprocessing:latest"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+exec /opt/spark/bin/spark-submit "$@" usace-programanalysis-geop.jar 2>&1


### PR DESCRIPTION
## Overview

Instead of building a JAR which gets included in a Docker image by the client repository, we publish a Docker image on Quay which can immediately be included by the client.

This branch is a cleaned up version of work done in [feature/hmc/docker](https://github.com/azavea/usace-program-analysis-geoprocessing/tree/feature/hmc/docker).
## Testing Instructions

Test Docker by running

```
$ ./sbt "project geop" assembly
$ docker build -t usace-geop-test .
$ docker run --rm --publish 127.0.0.1:8090:8090 usace-geop-test
$ curl http://localhost:8090
OK
```

Not sure what the best way is to test Travis, but one way is to see success in the [final build of the source branch](https://travis-ci.org/azavea/usace-program-analysis-geoprocessing/builds/135153748), and the diff between this work and the source branch:

`````` diff
diff --git a/.gitignore b/.gitignore
index 6d907a5..c3b4ce1 100644
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 .idea
-
-# CI Specific
-docker/*.jar
diff --git a/.travis.yml b/.travis.yml
index b61fdca..35e561b 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,14 @@ deploy:
     on:
       repo: azavea/usace-program-analysis-geoprocessing
       tags: true
+
   - provider: script
     script: "scripts/cibuild.sh"
     skip_cleanup: true
     on:
       repo: azavea/usace-program-analysis-geoprocessing
-      branch: feature/hmc/docker
+      branch: develop
+
   - provider: script
     script: "scripts/cibuild.sh"
     skip_cleanup: true
diff --git a/README.md b/README.md
index 207dcd4..a1a1fd8 100644
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ To test with the [main web app](https://github.com/azavea/usace-program-analysis

 ## Deploy

-Deployments to GitHub Releases are handled via [Travis-CI](https://travis-ci.org/azavea/usace-program-analysis-geoprocessing). The following `git-flow` commands signal to Travis that we want to create a release. The `version` variable should be updated in `project/Version.scala.`
+Deployments to [GitHub Releases](https://github.com/azavea/usace-program-analysis-geoprocessing/releases) and [Quay](https://quay.io/repository/usace/program-analysis-geoprocessing) are handled via [Travis-CI](https://travis-ci.org/azavea/usace-program-analysis-geoprocessing). The following `git-flow` commands signal to Travis that we want to create a release. The `version` variable should be updated in `project/Version.scala` and `Dockerfile`.

 ``` bash
 $ git flow release start 0.0.1
 $ vim CHANGELOG.md
 $ vim project/Version.scala
+$ vim Dockerfile
 $ git commit -m "0.0.1"
 $ git flow release publish 0.0.1
 $ git flow release finish 0.0.1
``````

Connects https://github.com/azavea/usace-program-analysis/issues/5
