### PR TITLE
Remove deprecated flag from docker tag command.

### DIFF
--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -12,5 +12,5 @@ fi
 docker build -t "quay.io/usace/program-analysis-geoprocessing:${QUAY_TAG}" .
 
 docker push "quay.io/usace/program-analysis-geoprocessing:${QUAY_TAG}"
-docker tag -f "quay.io/usace/program-analysis-geoprocessing:${QUAY_TAG}" "quay.io/usace/program-analysis-geoprocessing:latest"
+docker tag "quay.io/usace/program-analysis-geoprocessing:${QUAY_TAG}" "quay.io/usace/program-analysis-geoprocessing:latest"
 docker push "quay.io/usace/program-analysis-geoprocessing:latest"


### PR DESCRIPTION
Docker 1.10 deprecated, and 1.12 removed, the use of the `-f` flag for the `tag` command, as mentioned here --> https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag. Tags can now be assigned in any fashion, so I think removing the flag will fix the problem and the process will just continue as intended.

The test itself is to apply tags and then move them around, using `docker tag [imageid] somerepo:sometag` on an image, then trying `docker tag [another_imageid] somerepo:sometag` on another image to ensure that the tag can be reassigned to an image. I don't think this branch needs to be cloned to do so as long as the behavior of docker can be presumed to be consistent.

Getting multiple docker images can be done either by creating them directly, or in the case of this repo, I think doing a full compilation with `.sbt "project geop" assembly`, then `docker build -t  usace-geop-test .` would create an additional image. With a handful of images, tags could be shuffled around.

_Hopefully_ success locally translates to success during the build process.

Connects #6
