### PR TITLE
Add NLCD land use tile endpoint

### DIFF
--- a/geop/src/main/scala/com/azavea/usace/programanalysis/geop/GeopServiceActor.scala
+++ b/geop/src/main/scala/com/azavea/usace/programanalysis/geop/GeopServiceActor.scala
@@ -2,19 +2,21 @@ package com.azavea.usace.programanalysis.geop
 
 import akka.actor.Actor
 
-import geotrellis.proj4.{ConusAlbers, LatLng}
-
 import org.apache.spark.SparkContext
 
 import scala.concurrent.future
 
-import spray.http.AllOrigins
+import spray.http.{ AllOrigins, MediaTypes }
 import spray.http.HttpHeaders.{`Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Origin`}
 import spray.http.HttpMethods.{DELETE, GET, OPTIONS, POST}
 import spray.json.{JsNumber, JsObject}
 import spray.routing.{Directive0, HttpService, RejectionHandler}
 
-import scala.collection.parallel.immutable.ParVector
+import geotrellis.raster.Tile
+import geotrellis.spark.io.{TileNotFoundError}
+import geotrellis.proj4.{LatLng, ConusAlbers}
+import geotrellis.raster.{IntConstantNoDataCellType}
+import geotrellis.raster.render.{IntColorMap}
 
 
 class GeopServiceActor(sc: SparkContext) extends Actor with HttpService {
@@ -22,6 +24,18 @@ class GeopServiceActor(sc: SparkContext) extends Actor with HttpService {
   import JsonProtocol._
 
   implicit val _sc = sc
+
+  val NLCD_FOREST_COLOR: Int = 0x2B7B3D80
+  val NLCD_WETLANDS_COLOR: Int = 0x75A5D080
+  val NLCD_DISTURBED_COLOR: Int = 0xFF5D5D80
+
+  val nlcdColorMap =
+    new IntColorMap(Map(
+      41 -> NLCD_FOREST_COLOR, 42 -> NLCD_FOREST_COLOR, 43 -> NLCD_FOREST_COLOR,
+      90 -> NLCD_WETLANDS_COLOR, 95 -> NLCD_WETLANDS_COLOR,
+      21 -> NLCD_DISTURBED_COLOR, 22 -> NLCD_DISTURBED_COLOR, 23 -> NLCD_DISTURBED_COLOR,
+      24 -> NLCD_DISTURBED_COLOR, 81 -> NLCD_DISTURBED_COLOR, 82 -> NLCD_DISTURBED_COLOR
+    ))
 
   def actorRefFactory = context
   def receive = runRoute(root)
@@ -39,6 +53,7 @@ class GeopServiceActor(sc: SparkContext) extends Actor with HttpService {
 
   def root =
     pathPrefix("count") { rasterGroupedCount } ~
+    pathPrefix("nlcd-agg-tiles") { tilesHandler } ~
     path("ping") { complete { "OK" } }
 
   def rasterGroupedCount =
@@ -49,16 +64,39 @@ class GeopServiceActor(sc: SparkContext) extends Actor with HttpService {
         complete {
           future {
             args.multiPolygons.map(m => {
-              val multiPolygon = m.reproject(LatLng, ConusAlbers)
-              val rasterLayers = ClippedLayers(args.rasters, multiPolygon, sc)
-              val rasterGroupedCount = RasterGroupedCount(rasterLayers, multiPolygon)
+                val multiPolygon = m.reproject(LatLng, ConusAlbers)
+                val rasterLayers = ClippedLayers(args.rasters, multiPolygon, sc)
+                val rasterGroupedCount = RasterGroupedCount(rasterLayers, multiPolygon)
 
-              JsObject(
-                rasterGroupedCount
-                  .map { case (keys, count) =>
-                    keys.mkString(",") -> JsNumber(count)
-                  })
-              }).toVector
+                JsObject(
+                  rasterGroupedCount
+                    .map { case (keys, count) =>
+                      keys.mkString(",") -> JsNumber(count)
+                    })
+            }).toVector
+          }
+        }
+      }
+    }
+
+  def tilesHandler =
+    pathPrefix(IntNumber / IntNumber / IntNumber) { (zoom, x, y) =>
+      respondWithMediaType(MediaTypes.`image/png`) {
+        complete {
+          future {
+            val result: Option[Tile] =
+              try {
+                Some(ClippedLayers(zoom, x, y, sc))
+              } catch {
+                case _: TileNotFoundError => None
+              }
+
+            result.map { tile =>
+              tile
+                .convert(IntConstantNoDataCellType)
+                .renderPng(nlcdColorMap)
+                .bytes
+            }
           }
         }
       }

--- a/geop/src/main/scala/com/azavea/usace/programanalysis/geop/GeopServiceActor.scala
+++ b/geop/src/main/scala/com/azavea/usace/programanalysis/geop/GeopServiceActor.scala
@@ -16,7 +16,8 @@ import geotrellis.raster.Tile
 import geotrellis.spark.io.{TileNotFoundError}
 import geotrellis.proj4.{LatLng, ConusAlbers}
 import geotrellis.raster.{IntConstantNoDataCellType}
-import geotrellis.raster.render.{IntColorMap}
+import geotrellis.raster.render.{IntColorMap, ClassBoundaryType, Exact}
+import geotrellis.raster.render.ColorMap.{Options}
 
 
 class GeopServiceActor(sc: SparkContext) extends Actor with HttpService {
@@ -28,14 +29,17 @@ class GeopServiceActor(sc: SparkContext) extends Actor with HttpService {
   val NLCD_FOREST_COLOR: Int = 0x2B7B3D80
   val NLCD_WETLANDS_COLOR: Int = 0x75A5D080
   val NLCD_DISTURBED_COLOR: Int = 0xFF5D5D80
+  val NLCD_NO_DATA_COLOR: Int = 0xFFFFFF00
 
   val nlcdColorMap =
-    new IntColorMap(Map(
-      41 -> NLCD_FOREST_COLOR, 42 -> NLCD_FOREST_COLOR, 43 -> NLCD_FOREST_COLOR,
-      90 -> NLCD_WETLANDS_COLOR, 95 -> NLCD_WETLANDS_COLOR,
-      21 -> NLCD_DISTURBED_COLOR, 22 -> NLCD_DISTURBED_COLOR, 23 -> NLCD_DISTURBED_COLOR,
-      24 -> NLCD_DISTURBED_COLOR, 81 -> NLCD_DISTURBED_COLOR, 82 -> NLCD_DISTURBED_COLOR
-    ))
+    new IntColorMap(
+      Map(
+        41 -> NLCD_FOREST_COLOR, 42 -> NLCD_FOREST_COLOR, 43 -> NLCD_FOREST_COLOR,
+        90 -> NLCD_WETLANDS_COLOR, 95 -> NLCD_WETLANDS_COLOR,
+        21 -> NLCD_DISTURBED_COLOR, 22 -> NLCD_DISTURBED_COLOR, 23 -> NLCD_DISTURBED_COLOR,
+        24 -> NLCD_DISTURBED_COLOR, 81 -> NLCD_DISTURBED_COLOR, 82 -> NLCD_DISTURBED_COLOR),
+      new Options(classBoundaryType = Exact, noDataColor = NLCD_NO_DATA_COLOR, fallbackColor = NLCD_NO_DATA_COLOR)
+    )
 
   def actorRefFactory = context
   def receive = runRoute(root)

--- a/geop/src/main/scala/com/azavea/usace/programanalysis/geop/JsonProtocol.scala
+++ b/geop/src/main/scala/com/azavea/usace/programanalysis/geop/JsonProtocol.scala
@@ -13,18 +13,26 @@ import scala.collection.parallel.immutable.ParVector
 
 
 // TODO Nest under "input"
-case class CountArgs (rasters: Seq[LayerId], multiPolygons: ParVector[MultiPolygon])
+case class CountArgs (
+  rasters: Seq[LayerId],
+  multiPolygons: ParVector[MultiPolygon]
+)
 
 object JsonProtocol extends SprayJsonSupport with GeoJsonSupport {
   implicit object CountArgsJsonFormat extends RootJsonFormat[CountArgs] {
-    def write(args: CountArgs) = JsObject(
-      "zoom" -> JsNumber(args.rasters.head.zoom),
-      "rasters" -> JsArray(args.rasters.map(r => JsString(r.name)).toVector),
-      "multiPolygons" -> JsArray(args.multiPolygons.map(m => JsString(m.toGeoJson())).toVector)
-    )
+    def write(args: CountArgs) = args match {
+      case CountArgs(rasters, multiPolygons) =>
+        JsObject(
+          "zoom" -> JsNumber(rasters.head.zoom),
+          "rasters" -> JsArray(rasters.map(r => JsString(r.name)).toVector),
+          "multiPolygons" -> JsArray(multiPolygons.map(m => JsString(m.toGeoJson())).toVector)
+        )
+      case _ =>
+        throw new SerializationException("")
+    }
 
     def read(value: JsValue) = {
-      value.asJsObject.getFields("zoom", "rasters", "multiPolygons") match {
+      value.asJsObject.getFields("zoom", "rasters", "multiPolygons", "lat", "lng") match {
         case Seq(JsNumber(zoom), JsArray(rasters), JsArray(multiPolygons)) =>
           new CountArgs(
             rasters.map { r => LayerId(r.convertTo[String], zoom.toInt) },

--- a/geop/src/main/scala/com/azavea/usace/programanalysis/geop/JsonProtocol.scala
+++ b/geop/src/main/scala/com/azavea/usace/programanalysis/geop/JsonProtocol.scala
@@ -32,7 +32,7 @@ object JsonProtocol extends SprayJsonSupport with GeoJsonSupport {
     }
 
     def read(value: JsValue) = {
-      value.asJsObject.getFields("zoom", "rasters", "multiPolygons", "lat", "lng") match {
+      value.asJsObject.getFields("zoom", "rasters", "multiPolygons") match {
         case Seq(JsNumber(zoom), JsArray(rasters), JsArray(multiPolygons)) =>
           new CountArgs(
             rasters.map { r => LayerId(r.convertTo[String], zoom.toInt) },

--- a/geop/src/main/scala/com/azavea/usace/programanalysis/geop/LayerReader.scala
+++ b/geop/src/main/scala/com/azavea/usace/programanalysis/geop/LayerReader.scala
@@ -1,0 +1,53 @@
+package com.azavea.usace.programanalysis.geop
+
+import geotrellis.raster.Tile
+import geotrellis.spark.io._
+import geotrellis.spark.{SpatialKey, LayerId}
+import geotrellis.spark.io.s3.{S3AttributeStore, S3ValueReader}
+
+import org.apache.spark.SparkContext
+
+object LayerReader {
+  /**
+    * Given values for zoom, x and y, and a spark context, returns
+    * the corresponding [[Tile]] object.
+    *
+    * @param    zoom  [[Int]] value of zoom level
+    * @param    x     [[Int]] x-value of the spatial key
+    * @param    y     [[Int]] y-value of the spatial key
+    * @param    sc    [[SparkContext]] for the [[S3ValueReader]]
+    * @return         [[Tile]] object
+    */
+  def apply(
+    zoom: Int,
+    x: Int,
+    y: Int,
+    sc: SparkContext
+  ): Tile = {
+    val sKey = SpatialKey(x, y)
+    val rdr = catalog(sc, zoom)
+
+    rdr.read(sKey)
+  }
+
+  /**
+    * Given a spark context, returns the correct catalog. This configures the
+    * next method with defaults.
+    *
+    */
+  def catalog(sc: SparkContext, zoom: Int): Reader[SpatialKey, Tile] =
+    catalog("azavea-datahub", "catalog", zoom)(sc)
+
+  def catalog(
+    bucket: String,
+    rootPath: String,
+    zoom: Int
+  )(implicit sc: SparkContext): Reader[SpatialKey, Tile] = {
+    val attributeStore = new S3AttributeStore(bucket, rootPath)
+    val vr = new S3ValueReader(attributeStore)
+    val layer = LayerId("nlcd-zoomed", zoom)
+    val reader: Reader[SpatialKey, Tile] = vr.reader(layer)
+
+    reader
+  }
+}


### PR DESCRIPTION
Connects https://github.com/azavea/usace-program-analysis/issues/166

This adds an endpoint to the geoprocessing service at `/nlcd-agg-tiles` that takes requests in the typical `{zoom}/{x}/{y}` form and returns a PNG rendered from the NLCD land cover raster data.

To test -->
- clone this branch
- `cd` into the project directory
- execute `.sbt "project geop" assembly` to compile the service
- build the docker image with `docker build -t usace-geop-test .` 
- spin up a container with `docker run --rm -v ~/.aws:/root/.aws -p 4040:4040 -p 8090:8090 usace-geop-test --driver-memory 2g`
- using cURL or Postman or the like, send a `GET` request to `http://localhost:8090/ping` to ensure the service is available
- send a `GET` request to `http://localhost:8090/nlcd-agg-tiles/{zoom}/{x}/{y}` where zoom is a zoom level between 1-12, and x & y are row/column locations that are valid for that zoom level. 

The result should be a PNG that looks like it could be rendered from land cover data. For example, `http://localhost:8090/nlcd-agg-tiles/12/1194/1549` should return an image like this:
![1549](https://cloud.githubusercontent.com/assets/18290666/18319508/02fe579c-74f4-11e6-83e0-b3c6bad076b1.png)
